### PR TITLE
fix: inject scripts on main grammarly application page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "version": "1.0.0",
   "content_scripts": [
     {
-      "matches": ["https://app.grammarly.com/ddocs/*"],
+      "matches": ["https://app.grammarly.com/*"],
       "all_frames": true,
       "js":      ["scripts/content.js"]
     }
@@ -21,7 +21,7 @@
   "permissions": [
     "activeTab",
     "clipboardWrite",
-    "https://app.grammarly.com/ddocs/*"
+    "https://app.grammarly.com/*"
   ],
   "icons": {
     "48": "icon-48.png",


### PR DESCRIPTION
When the application navigates from the document selector to the document editor, it probably uses HTML PushState. This means that when it loads in the document editor, it doesn't actually load the extension.

The inconsistent issue mentioned in #1 is because if the user reloads the page, then the extension would be loaded correctly. This should solve #1.