### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Usage
 
-1. Open any document in Grammarly -- URL might be `https://app.grammarly.com/ddocs/*`
+1. Open any document in Grammarly -- URL might be `https://app.grammarly.com/docs/*`
 1. Click on the extension button on the toolbar
 1. It will be copied to your clipboard
 1. Profit 🚀


### PR DESCRIPTION
https://app.grammarly.com/ddocs/* to https://app.grammarly.com/docs/*
